### PR TITLE
Fix incorrect PINATA_GATEWAY environment variable in Next.js guide

### DIFF
--- a/frameworks/next-js.mdx
+++ b/frameworks/next-js.mdx
@@ -64,7 +64,7 @@ After making the project, create a `.env.local` file in the root of the project 
 
 ```
 PINATA_JWT=
-NEXT_PUBLIC_GATEWAY_URL=
+PINATA_GATEWAY=
 ```
 
 Use the `JWT` from the API key creation in the previous step as well as the `Gateway Domain`. The format of the Gateway domain should be `mydomain.mypinata.cloud`.
@@ -80,7 +80,7 @@ import { PinataSDK } from "pinata"
 
 export const pinata = new PinataSDK({
   pinataJwt: `${process.env.PINATA_JWT}`,
-  pinataGateway: `${process.env.NEXT_PUBLIC_GATEWAY_URL}`
+  pinataGateway: `${process.env.PINATA_GATEWAY}`
 })
 ```
 


### PR DESCRIPTION
This PR fixes a mistake in the Next.js setup guide regarding the use of environment variables.

The guide previously instructed users to use `NEXT_PUBLIC_GATEWAY_URL`, but the correct variable for server-side use is `PINATA_GATEWAY`.
